### PR TITLE
Return image url basing on path('public')

### DIFF
--- a/Libraries/Fields/Image.php
+++ b/Libraries/Fields/Image.php
@@ -69,7 +69,8 @@ class Image extends Field {
 		$this->sizeLimit = (int) array_get($info, 'size_limit', $this->sizeLimit);
 		$this->uploadUrl = \URL::to_route('admin_image_upload', array($config->name, $this->field));
 
-		$replace = 'public/';
+		$replace = path('public');
+
 
 		if (strpos($this->location, $replace) === 0)
 		{


### PR DESCRIPTION
Hi, I found a bug in Image display. Since it was first thing I thought of, and I'm only 2nd day in Laravel I'm not sure if that's the proper solution. There is, however, problem when using path('public') as shown on documentation for setting image location.

The change is:
Replace pattern was taking hardcoded '/public' to generate image url in editor. It was not consistent with user setting. Now it strips proper public path.
