### PR TITLE
Image field naming option and length of random method

### DIFF
--- a/Libraries/Fields/Image.php
+++ b/Libraries/Fields/Image.php
@@ -13,6 +13,13 @@ class Image extends Field {
 	public $naming = 'random';
 
 	/**
+	 * Length of file name if naming is set to random
+	 *
+	 * @var int
+	 */
+	public $length = 32;
+	
+	/**
 	 * The directory location used to store the original
 	 *
 	 * @var string
@@ -65,6 +72,7 @@ class Image extends Field {
 
 		$this->sizes = array_get($info, 'sizes', $this->sizes);
 		$this->naming = array_get($info, 'naming', $this->naming);
+		$this->naming = array_get($info, 'length', $this->length);
 		$this->location = array_get($info, 'location');
 		$this->sizeLimit = (int) array_get($info, 'size_limit', $this->sizeLimit);
 		$this->uploadUrl = \URL::to_route('admin_image_upload', array($config->name, $this->field));
@@ -94,6 +102,7 @@ class Image extends Field {
 		//use the multup library to perform the upload
 		$result = \Admin\Libraries\Includes\Multup::open('file', 'image|max:' . $this->sizeLimit * 1000 . '|mimes:jpg,gif,png', $this->location, $this->naming)
 			->sizes($this->sizes)
+			->set_length($this->length)
 			->upload();
 
 		return $result[0];

--- a/docs/field-type-image.md
+++ b/docs/field-type-image.md
@@ -14,6 +14,7 @@ The `image` field type should be a text-like type in your database. The image's 
 		'type' => 'image',
 		'location' => path('public') . 'uploads/products/originals/',
 		'naming' => 'random',
+		'length' => 20,
 		'size_limit' => 2,
 		'sizes' => array(
 			array(65, 57, 'crop', path('public') . 'uploads/products/thumbs/small/', 100),
@@ -27,6 +28,8 @@ In the edit form, an admin user will be presented with an image uploader. For th
 The required `location` option lets you define where the original image should be stored.
 
 The optional `naming` option lets you define whether to `keep` the file's name or to make the file name `random`. By default this is set to `random` in order to avoid naming collisions, but setting this to `keep` lets you keep your image's file names.
+
+The optional `length` option lets you define size of file name in case `random` is supplied as `naming` option method.  
 
 The optional `size_limit` option lets you set an integer size limit counted in megabytes. This only affects the JavaScript file uploading dialog, it doesn't limit your PHP upload sizes.
 


### PR DESCRIPTION
Image field naming option was hard coded.
Added length method for use cases where people need custom length of random file name than default 32 characters long.
