### PR TITLE
Fixing bug with CKeditor cursor jumping to beginning after editing

### DIFF
--- a/public/js/knockout/custom-bindings.js
+++ b/public/js/knockout/custom-bindings.js
@@ -335,7 +335,7 @@
 				editor = $element.ckeditorGet();
 
 			$element.html(value);
-			editor.setData(value);
+			editor.setData(value, null, true);
 		}
 	};
 


### PR DESCRIPTION
setData() was calling an internal event on CKeditor that made the cursor reset to the top
