### PR TITLE
Fixing sorting in relationships

### DIFF
--- a/Libraries/Fields/Relationships/Relationship.php
+++ b/Libraries/Fields/Relationships/Relationship.php
@@ -116,6 +116,7 @@ abstract class Relationship extends Field {
 
 		//get the name field option
 		$this->nameField = array_get($info, 'name_field', $this->nameField);
+		$this->sortField = array_get($info, 'sort_field', $this->nameField);
 		$this->autocomplete = array_get($info, 'autocomplete', $this->autocomplete);
 		$this->numOptions = array_get($info, 'num_options', $this->numOptions);
 		$this->searchFields = array_get($info, 'search_fields', array($this->nameField));


### PR DESCRIPTION
I found that the ordering was doing previous to the specific controller (many to many, has many) because it was done in the parent, then, if you putted some getter it will take an error because it didn't found a name_field in the DB and it was not taking the sorting field, with this option it adds the sortField if exists and if not still uses the nameField
