### PR TITLE
Now it is possible to specify a getter in 'field_name' on relationship

### DIFF
--- a/Libraries/Fields/Relationships/Relationship.php
+++ b/Libraries/Fields/Relationships/Relationship.php
@@ -28,6 +28,13 @@ abstract class Relationship extends Field {
 	public $nameField = 'name';
 
 	/**
+	 * The name of the column for sorting on the other table
+	 *
+	 * @var string
+	 */
+	public $sortField;
+
+	/**
 	 * The symbol to use in front of the number
 	 *
 	 * @var string
@@ -116,6 +123,7 @@ abstract class Relationship extends Field {
 
 		//get the name field option
 		$this->nameField = array_get($info, 'name_field', $this->nameField);
+		$this->sortField = array_get($info, 'sort_field', $this->nameField);
 		$this->autocomplete = array_get($info, 'autocomplete', $this->autocomplete);
 		$this->numOptions = array_get($info, 'num_options', $this->numOptions);
 		$this->searchFields = array_get($info, 'search_fields', array($this->nameField));
@@ -129,7 +137,7 @@ abstract class Relationship extends Field {
 
 		if (array_get($info, 'load_relationships', false))
 		{
-			$options = $relationship->model->order_by($this->nameField)->get();
+			$options = $relationship->model->order_by($this->sortField)->get();
 		}
 		//otherwise if there are relationship items, we need them in the initial options list
 		else if ($relationshipItems = $relationship->get())

--- a/docs/field-type-relationship.md
+++ b/docs/field-type-relationship.md
@@ -21,7 +21,8 @@ Relationship field types allow you to manage the `belongs_to` and `has_many_and_
 	'user' => array(
 		'type' => 'relationship',
 		'title' => 'User',
-		'name_field' => 'name', //what column or getter on the other table you want to use to represent this object
+		'name_field' => 'fullname', //what column or getter on the other table you want to use to represent this object
+		'sort_field' => 'username', //if this is not specified, name_field will be used for sorting
 	)
 
 The `name_field` option lets you define which column on the other table will be used to represent the relationship. This field might be used in this model:


### PR DESCRIPTION
When 'sort_field' option is specified only (for backward compability).
If it isn't specified, 'name_field' will be used as column name for
sorting.
