### PR TITLE
Show a logout button in the admin header and fixes #120

### DIFF
--- a/examples/app/config/frozennode/administrator/administrator.php
+++ b/examples/app/config/frozennode/administrator/administrator.php
@@ -84,6 +84,13 @@ return array(
 	'login_path' => 'user/login',
 
 	/**
+	 * The logout path is the path where Administrator will send the user when they click the logout link
+	 *
+	 * @type string
+	 */
+	'logout_path' => 'user/logout',
+
+	/**
 	 * Redirect key
 	 *
 	 * @type string

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -314,6 +314,21 @@ body label {
   background:linear-gradient(top,#444444 0%,#333333 100%);
   filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#444444',endColorstr='#333333',GradientType=0);
 }
+#wrapper header div#right_nav a#logout {
+  display:inline-block;
+  margin-left:-3px;
+  padding:9px 12px 8px;
+}
+#wrapper header div#right_nav a#logout:hover {
+  background:#444444;
+  background:-moz-linear-gradient(top,#444444 0%,#333333 100%);
+  background:-webkit-gradient(linear,left top,left bottom,color-stop(0%,#333333),color-stop(100%,#333333));
+  background:-webkit-linear-gradient(top,#444444 0%,#333333 100%);
+  background:-o-linear-gradient(top,#444444 0%,#333333 100%);
+  background:-ms-linear-gradient(top,#444444 0%,#333333 100%);
+  background:linear-gradient(top,#444444 0%,#333333 100%);
+  filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#444444',endColorstr='#333333',GradientType=0);
+}
 #admin_page { position:relative; }
 #admin_page label {
   margin-bottom:3px;

--- a/public/css/main.less
+++ b/public/css/main.less
@@ -153,6 +153,16 @@ body{
 					@verticalGradient(#444, #333);
 				}
 			}
+
+			a#logout {
+				display: inline-block;
+				margin-left: -3px;
+				@headerButtonPadding;
+
+				&:hover {
+					@verticalGradient(#444, #333);
+				}
+			}
 		}
 	}
 

--- a/src/config/administrator.php
+++ b/src/config/administrator.php
@@ -91,6 +91,13 @@ return array(
 	'login_path' => 'user/login',
 
 	/**
+	 * The logout path is the path where Administrator will send the user when they click the logout link
+	 *
+	 * @type string
+	 */
+	'logout_path' => 'user/logout',
+
+	/**
 	 * This is the key of the return path that is sent with the redirection to your login_action. Input::get('redirect') will hold the return URL.
 	 *
 	 * @type string

--- a/src/docs/configuration.md
+++ b/src/docs/configuration.md
@@ -30,6 +30,7 @@ Below is a list of all the available options:
 - [Dashboard View](#dashboard-view)
 - [Home Page](#home-page)
 - [Login Path](#login-path)
+- [Logout Path](#logout-path)
 - [Redirect Key](#redirect-key)
 - [Global Rows Per Page](#global-rows-per-page)
 - [Locales](#locales)
@@ -180,6 +181,18 @@ The permission option lets you define a closure that determines whether or not t
 	'login_path' => 'user/login',
 
 Provide any value that would work with Laravel's `URL::to()` method.
+
+<a name="logout-path"></a>
+### Logout Path
+
+	/**
+	 * The logout path is the path where Administrator will send the user when they click the logout link
+	 *
+	 * @type string
+	 */
+	'logout_path' => 'user/logout',
+
+Provide any value that would work with Laravel's `URL::to()` method. If you don't want the logout link just set it to null, 'logout_path' => null, instead of a link.
 
 <a name="redirect-key"></a>
 ### Redirect Key

--- a/src/lang/de/administrator.php
+++ b/src/lang/de/administrator.php
@@ -28,6 +28,7 @@ return array(
 	'itemsperpage' => 'Artikel pro Seite',
 	'noresults' => 'Keine Resultate',
 	'backtosite' => 'Zurück zur Website',
+	'logout' => 'Abmeldung',
 
 	'previous' => 'Zurück',
 	'next' => 'Weiter',

--- a/src/lang/en/administrator.php
+++ b/src/lang/en/administrator.php
@@ -28,6 +28,7 @@ return array(
 	'itemsperpage' => 'items per page',
 	'noresults' => 'No Results',
 	'backtosite' => 'Back to Site',
+	'logout' => 'Logout',
 
 	'previous' => 'prev',
 	'next' => 'next',

--- a/src/lang/es/administrator.php
+++ b/src/lang/es/administrator.php
@@ -28,6 +28,7 @@ return array(
 	'itemsperpage' => 'ítems por página',
 	'noresults' => 'Sin Resultados',
 	'backtosite' => 'Volver al Sitio',
+	'logout' => 'Logout',
 
 	'previous' => 'anterior',
 	'next' => 'siguiente',

--- a/src/lang/eu/administrator.php
+++ b/src/lang/eu/administrator.php
@@ -28,6 +28,7 @@ return array(
 	'itemsperpage' => 'item orrialdeko',
 	'noresults' => 'Emaitzik Ez',
 	'backtosite' => 'Tokira Itzuli',
+	'logout' => 'Logout',
 
 	'previous' => 'aurrekoa',
 	'next' => 'hurrengoa',

--- a/src/lang/fr/administrator.php
+++ b/src/lang/fr/administrator.php
@@ -28,6 +28,7 @@ return array(
 	'itemsperpage' => 'éléments par page',
 	'noresults' => 'Aucun résultat',
 	'backtosite' => 'Retour au site',
+	'logout' => 'Déconnexion',
 
 	'previous' => 'préc',
 	'next' => 'suiv',

--- a/src/lang/hu/administrator.php
+++ b/src/lang/hu/administrator.php
@@ -28,6 +28,7 @@ return array(
 	'itemsperpage' => 'sor oldalanként',
 	'noresults' => 'Nincs eredmény',
 	'backtosite' => 'Vissza az oldalra',
+	'logout' => 'Logout',
 
 	'previous' => 'előző',
 	'next' => 'következő',

--- a/src/lang/nl/administrator.php
+++ b/src/lang/nl/administrator.php
@@ -28,6 +28,7 @@ return array(
 	'itemsperpage' => 'items per pagina',
 	'noresults' => 'Geen Resultaten',
 	'backtosite' => 'Terug naar de Site',
+	'logout' => 'Afmelden',
 
 	'previous' => 'vorige',
 	'next' => 'volgende',

--- a/src/lang/pl/administrator.php
+++ b/src/lang/pl/administrator.php
@@ -28,6 +28,7 @@ return array(
 	'itemsperpage'   => 'pozycji na stronie',
 	'noresults'      => 'Brak wynikow',
 	'backtosite'     => 'Powrót do strony',
+	'logout' 		 => 'Wyloguj',
 
 	'previous' => 'poprzedni',
 	'next'     => 'następny',

--- a/src/lang/pt-BR/administrator.php
+++ b/src/lang/pt-BR/administrator.php
@@ -28,6 +28,7 @@ return array(
 	'itemsperpage' => 'itens por página',
 	'noresults' => 'Sem Resultados',
 	'backtosite' => 'Voltar para o Site',
+	'logout' => 'Logout',
 
 	'previous' => 'anterior',
 	'next' => 'próximo',

--- a/src/lang/sr/administrator.php
+++ b/src/lang/sr/administrator.php
@@ -28,6 +28,7 @@ return array(
 	'itemsperpage' => 'stavki po strani',
 	'noresults' => 'Nema rezultata',
 	'backtosite' => 'Nazad na sajt',
+	'logout' => 'Одјава',
 
 	'previous' => 'pred',
 	'next' => 'sled',

--- a/src/lang/tr/administrator.php
+++ b/src/lang/tr/administrator.php
@@ -28,6 +28,7 @@ return array(
 	'itemsperpage' => 'Sayfa Başına Kalem',
 	'noresults' => 'Bulunamadı',
 	'backtosite' => 'Siteye Dön',
+	'logout' => 'Çıkış',
 
 	'previous' => 'önceki',
 	'next' => 'sonraki',

--- a/src/lang/zh-CN/administrator.php
+++ b/src/lang/zh-CN/administrator.php
@@ -28,6 +28,7 @@ return array(
 	'itemsperpage' => '条目每页',
 	'noresults' => '没有结果',
 	'backtosite' => '返回主站',
+	'logout' => '退出'
 
 	'previous' => '上一页',
 	'next' => '下一页',

--- a/src/views/partials/header.blade.php
+++ b/src/views/partials/header.blade.php
@@ -50,6 +50,9 @@
 				</li>
 			</ul>
 		@endif
+		@if(Config::get('administrator::administrator.logout_path'))
+			<a href="{{URL::to(Config::get('administrator::administrator.logout_path'))}}" id="logout">{{trans('administrator::administrator.logout')}}</a>
+		@endif
 		<a href="{{URL::to('/')}}" id="back_to_site">{{trans('administrator::administrator.backtosite')}}</a>
 	</div>
 </header>


### PR DESCRIPTION
Fixes #120 

A logout button will be generated next to the back to the site link in the header if in the admin configuration array a setting is set as 'logout_path' => 'user/logout' if not the logout button will be ignored!

This commit also fixes the stylesheet, examples, documentation and translation files...
