### PR TITLE
count_query fails for models using an alternate database connection

### DIFF
--- a/src/Frozennode/Administrator/ModelHelper.php
+++ b/src/Frozennode/Administrator/ModelHelper.php
@@ -155,7 +155,7 @@ class ModelHelper {
 			}
 
 			//temporarily update the model on the config object
-			$config->model = $model::find($model->id);
+			$config->model = $model::find($model->getKey());
 
 			//set up the model with the edit fields new data
 			$editFields = Field::getEditFields($config);


### PR DESCRIPTION
If an Eloquent model has

```
protected $connection='my_alternate_connection'
```

set, ModelHelper::getRows() will throw an error when the count_query tries to re-run the query using the default connection.
