### PR TITLE
count_query fails for models using an alternate database connection

### DIFF
--- a/src/Frozennode/Administrator/DataTable/DataTable.php
+++ b/src/Frozennode/Administrator/DataTable/DataTable.php
@@ -86,7 +86,7 @@ class DataTable {
 		$keyName = $model->getKeyName();
 		$query = $model->groupBy($table . '.' . $keyName);
 		$dbQuery = $query->getQuery();
-		$countQuery = $db->table($table)->groupBy($table . '.' . $keyName);
+		$countQuery = $dbQuery->connection()->table($table)->groupBy($table . '.' . $keyName);
 
 		//set up initial array states for the selects
 		$selects = array($table.'.*');


### PR DESCRIPTION
If an Eloquent model has

```
protected $connection='my_alternate_connection'
```

set, DataTable::getRows() will throw an error when the count_query tries to re-run the query using the default connection.
