### PR TITLE
Fixed bug in Route::filter

### DIFF
--- a/src/filters.php
+++ b/src/filters.php
@@ -5,7 +5,7 @@
 //validate_admin filter
 Route::filter('validate_admin', function ()
 {
-	$configFactory = $this->app->make('admin_config_factory');
+	$configFactory = App::make('admin_config_factory');
 
 	//set the locale
 	$locale = Session::get('administrator_locale');


### PR DESCRIPTION
In my system, there was an error when it attempted to set the $configFactory variable:

Using $this when not in object context

Existing code used $this->app->make(); changed it to App::make()
