### PR TITLE
Compatibility fix in delete function

### DIFF
--- a/src/controllers/AdminController.php
+++ b/src/controllers/AdminController.php
@@ -149,7 +149,8 @@ class AdminController extends Controller
 		);
 
 		//if the model or the id don't exist, send back 404
-		$permissions = $actionFactory->getActionPermissions()
+		$permissions = $actionFactory->getActionPermissions();
+		
 		if (!$model->exists || !$permissions['delete'])
 		{
 			return Response::json($errorResponse);


### PR DESCRIPTION
php 5.3 does not support $object->getArray()['ArrayItem'] notation.
