### PR TITLE
Fixed bug in Route::filter

### DIFF
--- a/src/filters.php
+++ b/src/filters.php
@@ -5,7 +5,7 @@
 //validate_admin filter
 Route::filter('validate_admin', function ()
 {
-	$configFactory = $this->app->make('admin_config_factory');
+	$configFactory = App::make('admin_config_factory');
 
 	//set the locale
 	$locale = Session::get('administrator_locale');


### PR DESCRIPTION
Error when attempting to set the $configFactory variable in app/route::filter:

```
Using $this when not in object context
```

Existing code used $this->app->make(); changed it to App::make()
