### PR TITLE
Fixed missing return in the Time field that stopped the 'time' field val...

### DIFF
--- a/src/Frozennode/Administrator/Fields/Time.php
+++ b/src/Frozennode/Administrator/Fields/Time.php
@@ -102,7 +102,7 @@ class Time extends Field {
 		}
 		else
 		{
-			date('H:i:s', $time);
+			return date('H:i:s', $time);
 		}
 	}
 }


### PR DESCRIPTION
I was using the 'time' field ant it wasn't saving the value. I spotted it was a missing return in the Time field.
It's my first pull request, and I messed up my username when committing, hence user being "root"!
