### PR TITLE
Urgent fix to prevent error with latest laravel

### DIFF
--- a/src/Frozennode/Administrator/Validator.php
+++ b/src/Frozennode/Administrator/Validator.php
@@ -62,7 +62,7 @@ class Validator extends \Illuminate\Validation\Validator {
 	 *
 	 * @param array		$rules
 	 */
-	public function setRules($rules)
+	public function setRules(array $rules)
 	{
 		$this->rules = $this->explodeRules($rules);
 	}


### PR DESCRIPTION
Currently throws ErrorException
Declaration of Frozennode\Administrator\Validator::setRules() should be compatible with Illuminate\Validation\Validator::setRules(array $rules)
