### PR TITLE
Use `detach` instead of `delete`.

### DIFF
--- a/src/Frozennode/Administrator/Fields/Relationships/BelongsToMany.php
+++ b/src/Frozennode/Administrator/Fields/Relationships/BelongsToMany.php
@@ -49,31 +49,25 @@ class BelongsToMany extends Relationship {
 	public function fillModel(&$model, $input)
 	{
 		$input = $input ? explode(',', $input) : array();
-		$editable = $this->getOption('editable');
 		$fieldName = $this->getOption('field_name');
+		$relationship = $model->{$fieldName}();
 
-		//touch attribute on the model only if the field editable
-		if ($editable)
+		//if this field is sortable, delete all the old records and insert the new ones one at a time
+		if ($sortField = $this->getOption('sort_field'))
 		{
-			$relationship = $model->{$fieldName}();
+			//first delete all the old records
+			$relationship->detach();
 
-			//if this field is sortable, delete all the old records and insert the new ones one at a time
-			if ($sortField = $this->getOption('sort_field'))
+			//then re-attach them in the correct order
+			foreach ($input as $i => $item)
 			{
-				//first delete all the old records
-				$relationship->detach();
-
-				//then re-attach them in the correct order
-				foreach ($input as $i => $item)
-				{
-					$relationship->attach($item, array($sortField => $i));
-				}
+				$relationship->attach($item, array($sortField => $i));
 			}
-			else
-			{
-				//elsewise the order doesn't matter, so use sync
-				$relationship->sync($input);
-			}
+		}
+		else
+		{
+			//elsewise the order doesn't matter, so use sync
+			$relationship->sync($input);
 		}
 
 		//unset the attribute on the model

--- a/tests/Fields/Relationships/BelongsToManyTest.php
+++ b/tests/Fields/Relationships/BelongsToManyTest.php
@@ -84,18 +84,10 @@ class BelongsToManyTest extends \PHPUnit_Framework_TestCase {
 		$this->field->build();
 	}
 
-	public function testFillModelNonEditable()
-	{
-		$model = new BelongsToManyEloquentStub;
-		$this->field->shouldReceive('getOption')->times(3)->andReturn('false', 'fieldSort');
-		$this->field->fillModel($model, '3,4,5');
-		$this->assertTrue(!isset($model->rel));
-	}
-
 	public function testFillModelWithSortField()
 	{
 		$model = new BelongsToManyEloquentStub;
-		$this->field->shouldReceive('getOption')->times(3)->andReturn('true', 'fieldSort', 'sort');
+		$this->field->shouldReceive('getOption')->twice()->andReturn('fieldSort', 'sort');
 		$this->field->fillModel($model, '3,4,5');
 		$this->assertTrue(!isset($model->rel));
 	}
@@ -103,7 +95,7 @@ class BelongsToManyTest extends \PHPUnit_Framework_TestCase {
 	public function testFillModelWithoutSortField()
 	{
 		$model = new BelongsToManyEloquentStub;
-		$this->field->shouldReceive('getOption')->times(3)->andReturn('true', 'fieldNoSort', false);
+		$this->field->shouldReceive('getOption')->twice()->andReturn('fieldNoSort', false);
 		$this->field->fillModel($model, '3,4,5');
 		$this->assertTrue(!isset($model->rel));
 	}


### PR DESCRIPTION
Using `delete` cause an error. Use `detach` instead of `delete`.
