### PR TITLE
Allowing the Redirect::Intended to work by using Redirect::guest

### DIFF
--- a/src/filters.php
+++ b/src/filters.php
@@ -18,7 +18,7 @@ Route::filter('validate_admin', function ()
 		$redirectKey = Config::get('administrator::administrator.login_redirect_key', 'redirect');
 		$redirectUri = Request::url();
 
-		return Redirect::to($loginUrl)->with($redirectKey, $redirectUri);
+		return Redirect::guest($loginUrl)->with($redirectKey, $redirectUri);
 	}
 	//otherwise if this is a response, return that
 	else if (is_a($response, 'Illuminate\Http\JsonResponse') || is_a($response, 'Illuminate\Http\Response'))


### PR DESCRIPTION
I would like to be able to use the Redirect::Intended in my authentication service, but you are using the Redirect::to in your filter on line 21.  This merge request is to swap that out to the Redirect::guest, which flashes 'url.intended' into session, and then calls the same method as Redirect::to.
