### PR TITLE
Authentication intercept redirects to intended page

### DIFF
--- a/src/filters.php
+++ b/src/filters.php
@@ -18,7 +18,7 @@ Route::filter('validate_admin', function ()
 		$redirectKey = Config::get('administrator::administrator.login_redirect_key', 'redirect');
 		$redirectUri = Request::url();
 
-		return Redirect::to($loginUrl)->with($redirectKey, $redirectUri);
+		return Redirect::guest($loginUrl)->with($redirectKey, $redirectUri);
 	}
 	//otherwise if this is a response, return that
 	else if (is_a($response, 'Illuminate\Http\JsonResponse') || is_a($response, 'Illuminate\Http\Response'))


### PR DESCRIPTION
Submitting PR to dev branch as requested.

In the route filters, 'validate_admin' Redirects "::to" the login URL. In at least my setup, this prevents the login page from sending you where you tried to get to.

By utilizing Laravel's Redirect::guest, it sets the session up to send the user to the intended page when authentication is complete.
