### PR TITLE
Bug fix with routing

### DIFF
--- a/src/Frozennode/Administrator/Config/Factory.php
+++ b/src/Frozennode/Administrator/Config/Factory.php
@@ -301,7 +301,7 @@ class Factory {
 	public function fetchConfigFile($name)
 	{
 		$name = str_replace($this->getPrefix(), '', $name);
-		$path = $this->getPath() . $name . '.php';
+        $path = $this->getPath() . str_replace('.','/',$name) . '.php';
 
 		//check that this is a legitimate file
 		if (is_file($path))


### PR DESCRIPTION
This should solve routing errors for anyone who wants to separate their admin config into several modules.

The configuration I'm using this with:
'model_config_path' => app('path') . '/modules',

'menu' => array(
        'Categories' => array('biz.config.admin.category'),
        //'Settings' => array('settings.site'),
),

If there is already a more proper way to handle this that I missed in the documentation please let me know!
