### PR TITLE
 Prevent class redeclaration errors in Laravel 4.1 phpunit tests

### DIFF
--- a/src/Frozennode/Administrator/AdministratorServiceProvider.php
+++ b/src/Frozennode/Administrator/AdministratorServiceProvider.php
@@ -34,10 +34,12 @@ class AdministratorServiceProvider extends ServiceProvider {
 		$this->app['administrator.4.1'] = version_compare(\Illuminate\Foundation\Application::VERSION, '4.1') > -1;
 
 		//set up an alias for the base laravel controller to accommodate >=4.1 and <4.1
-		if ($this->app['administrator.4.1'])
-			class_alias('Illuminate\Routing\Controller', 'AdministratorBaseController');
-		else
-			class_alias('Illuminate\Routing\Controllers\Controller', 'AdministratorBaseController');
+		if (!class_exists('AdministratorBaseController')){ // Verify alias is not already created
+			if ($this->app['administrator.4.1'])
+				class_alias('Illuminate\Routing\Controller', 'AdministratorBaseController');
+			else
+				class_alias('Illuminate\Routing\Controllers\Controller', 'AdministratorBaseController');
+		}
 
 		//include our filters, view composers, and routes
 		include __DIR__.'/../../filters.php';


### PR DESCRIPTION
Added class_exists check to AdministratorServiceProvider boot to prevent redefinition of AdministratorBaseController alias. This prevents the following error in Laravel 4.1 phpunit tests: 

ErrorException: Cannot redeclare class AdministratorBaseController

/Users/ed/Dev/Gloo/portal-v2/vendor/frozennode/administrator/src/Frozennode/Administrator/AdministratorServiceProvider.php:38
/Users/ed/Dev/Gloo/portal-v2/vendor/laravel/framework/src/Illuminate/Foundation/Application.php:496
/Users/ed/Dev/Gloo/portal-v2/vendor/laravel/framework/src/Illuminate/Foundation/Application.php:496
/Users/ed/Dev/Gloo/portal-v2/vendor/laravel/framework/src/Illuminate/Foundation/Testing/TestCase.php:48
/Users/ed/Dev/Gloo/portal-v2/vendor/laravel/framework/src/Illuminate/Foundation/Testing/TestCase.php:31
/Users/ed/Dev/Gloo/portal-v2/app/tests/TestCase.php:23
