### PR TITLE
Allow closure within column 'output' option

### DIFF
--- a/src/Frozennode/Administrator/DataTable/Columns/Column.php
+++ b/src/Frozennode/Administrator/DataTable/Columns/Column.php
@@ -78,8 +78,7 @@ class Column {
 		'column_name' => 'required|string',
 		'title' => 'string',
 		'relationship' => 'string',
-		'select' => 'required_with:relationship|string',
-		'output' => 'string',
+		'select' => 'required_with:relationship|string'
 	);
 
 	/**
@@ -241,13 +240,19 @@ class Column {
 	/**
 	 * Takes a column output string and renders the column with it (replacing '(:value)' with the column's field value)
 	 *
-	 * @param string	$output
+	 * @param string	$value
 	 *
 	 * @return string
 	 */
 	public function renderOutput($value)
 	{
-		return str_replace('(:value)', $value, $this->getOption('output'));
+		$output = $this->getOption('output');
+		
+		if (is_callable($output)) {
+			return $output($value);
+		}
+		
+		return str_replace('(:value)', $value, $output);
 	}
 
 	/**


### PR DESCRIPTION
This change allows the column definition's 'output' option to be a closure.

In my particular use case, I had a column containing a JSON string that was automatically converted to an array in my model's get[Field]Attribute() call. This was causing 'array-to-string' conversion issues with Administrator, and I wanted to have better control on how that looked, anyway.

My Administrator model config now looks something like:

``` php
return array(
    'title'       => 'Attributes',
    'single'      => 'Attribute',
    'model'       => 'Attribute',

    'columns'     => array(
        'code' => array(
            'title' => 'Code'
        ),
        'config'         => array(
            'title' => 'Config',
            'output' => function($value) {
                return join(', ', array_values($value));
            }
        )
    ),
   [...]
);
```
