### PR TITLE
Fixed relationship options_filter error

### DIFF
--- a/src/Frozennode/Administrator/Fields/Relationships/Relationship.php
+++ b/src/Frozennode/Administrator/Fields/Relationships/Relationship.php
@@ -73,7 +73,10 @@ abstract class Relationship extends Field {
 
 		//make sure the options filter is set up
 		$options['options_filter'] = $this->validator->arrayGet($options, 'options_filter') ?: function() {};
-
+		
+		if($options['options_filter'] === null){
+			$options['options_filter'] = function(){};
+		}
 		//set up and check the constraints
 		$this->setUpConstraints($options);
 


### PR DESCRIPTION
--fixed a bug with "Function name must be a string" in line 150 of Relationships/Relationship.php due to the assignment in line 75 which was going to set 'options_filter' as closure, but I believe it set it as function result instead, which is null in that case
