### PR TITLE
When a model has bindings by default for it's standard query we need to ...

### DIFF
--- a/src/Frozennode/Administrator/DataTable/DataTable.php
+++ b/src/Frozennode/Administrator/DataTable/DataTable.php
@@ -121,6 +121,7 @@ class DataTable {
 		//get the Illuminate\Database\Query\Builder instance and set up the count query
 		$dbQuery = $query->getQuery();
 		$countQuery = $dbQuery->getConnection()->table($table)->groupBy($table . '.' . $keyName);
+		$countQuery->mergeBindings($dbQuery);
 
 		//run the supplied query filter for both queries if it was provided
 		$this->config->runQueryFilter($dbQuery);

--- a/tests/DataTable/DataTableTest.php
+++ b/tests/DataTable/DataTableTest.php
@@ -89,6 +89,7 @@ class DataTableTest extends \PHPUnit_Framework_TestCase {
 		$dbQuery = m::mock('Illuminate\Database\Query\Builder');
 		$dbQuery->shouldReceive('select')->twice()
 				->shouldReceive('getConnection')->once()->andReturn($connection);
+		$countQuery->shouldReceive('mergeBindings')->once();
 		$query = m::mock('Illuminate\Database\Eloquent\Builder');
 		$query->shouldReceive('getQuery')->twice()->andReturn($dbQuery)
 				->shouldReceive('toSql')->once()->andReturn('sql string')


### PR DESCRIPTION
...merge the Model's query with our count query so that it has the bindings required to complete the count.