### PR TITLE
scrollable dataTable

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1173,6 +1173,10 @@ body label {
 #admin_page #content div.table_container div.page_container div.per_page input[type=hidden] {
   width: 70px;
 }
+#admin_page #content div.table_container div.table_scrollable {
+  width:100%;
+  overflow-x:auto;
+}
 #admin_page #content div.table_container table.results {
   width: 100%;
   margin-bottom: 10px;

--- a/public/css/main.less
+++ b/public/css/main.less
@@ -427,6 +427,11 @@ body{
 				}
 			}
 
+			div.table_scrollable {
+				width:100%;
+				overflow-x:auto;
+			}
+
 			table.results {
 				width: 100%;
 				margin-bottom: 10px;

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -31,6 +31,14 @@
 		$dataTable: null,
 
 		/*
+		 * If this is true, the dataTable is scrollable instead of
+		 * skipping columns at the end
+		 *
+		 * @type bool
+		 */
+		dataTableScrollable: false,
+
+		/*
 		 * The pixel points where the columns are hidden
 		 *
 		 * @type object
@@ -1484,9 +1492,31 @@
 			//resize the page height
 			$('#admin_page').css({minHeight: usedHeight});
 
-			//resize the data table
-			if (window.admin)
-				window.admin.resizeDataTable();
+			//resize or scroll the data table
+			if (window.admin) {
+				if (! window.admin.dataTableScrollable)
+					window.admin.resizeDataTable();
+				else
+				window.admin.scrollDataTable();
+			}
+		},
+
+		/**
+		 * Allows to scroll wide data tables (alternative to resizeDataTable)
+		 */
+		scrollDataTable: function()
+		{
+			if (!self.$tableContainer)
+			{
+				self.$tableContainer = $('div.table_container');
+				self.$dataTable = self.$tableContainer.find('table.results');
+			}
+
+			// exit if table is already wrapped
+			if (self.$dataTable.parent().hasClass('table_scrollable')) return true;
+
+			// wrap table within div.table_scrollable
+			self.$dataTable.wrap('<div class="table_scrollable"></div>')
 		},
 
 		/**


### PR DESCRIPTION
- allow horizontal scrolling of dataTable instead of skipping columns at the end
- just set admin.dataTableScrollable value to true (admin.js; default is false)
