### PR TITLE
fix fatal error in Relationship softDelete

### DIFF
--- a/src/Frozennode/Administrator/DataTable/Columns/Relationships/Relationship.php
+++ b/src/Frozennode/Administrator/DataTable/Columns/Relationships/Relationship.php
@@ -96,8 +96,11 @@ class Relationship extends Column {
 		//one element of the relationship query's wheres is always useless (it will say pivot_table.other_id is null)
 		//depending on whether or not softdeletes are enabled on the other model, this will be in either position 0
 		//or 1 of the wheres array
-		array_splice($query->wheres, ($relationshipModel->isSoftDeleting() ? 1 : 0), 1);
-
+		if (method_exists($relationshipModel, 'isSoftDeleting'))
+        	{
+			array_splice($query->wheres, ($relationshipModel->isSoftDeleting() ? 1 : 0), 1);
+        	}
+		
 		//iterate over the wheres to properly alias the columns
 		foreach ($query->wheres as &$where)
 		{


### PR DESCRIPTION
I was getting a fatal error this fixes it. The error was:

BadMethodCallException
Call to undefined method Illuminate\Database\Query\Builder::isSoftDeleting()
