### PR TITLE
Fix CSS syntax error in main.less that prevents most less compilers to run/build

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1269,7 +1269,7 @@ body label {
   bottom: 0;
   background-color: #000;
   opacity: 0.50;
-  -ms-filter: "progid:DXImageTransform.Microsoft.Alpha" false;
+  -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=50)";
   filter: progid:DXImageTransform.Microsoft.Alpha(opacity=50);
   filter: alpha(opacity=50);
   text-align: center;

--- a/public/css/main.less
+++ b/public/css/main.less
@@ -531,7 +531,7 @@ body{
 				bottom: 0;
 				background-color: #000;
 				opacity: 0.50;
-				-ms-filter:"progid:DXImageTransform.Microsoft.Alpha"(Opacity=50);
+				-ms-filter:"progid:DXImageTransform.Microsoft.Alpha(Opacity=50)";
 				filter: progid:DXImageTransform.Microsoft.Alpha(opacity=50);
 				filter: alpha(opacity=50);
 				text-align: center;


### PR DESCRIPTION
When I was working on the fix for #661, I found this problem.
Tried several less compilers, none of them could run due to this issue.

<i>Can you please reply to me at #661 which less compiler are you using and what are the settings? Because I tried several but they all resulted in too many changes in the final css.</i>
