### PR TITLE
[Fix] Non relation methods converted to Collection

### DIFF
--- a/src/Frozennode/Administrator/Fields/Factory.php
+++ b/src/Frozennode/Administrator/Fields/Factory.php
@@ -463,8 +463,8 @@ class Factory {
 			}
 			else
 			{
-				//if this is a collection, convert it to an array
-				if (is_a($model->$name, 'Illuminate\Database\Eloquent\Collection'))
+				//if this is a collection (when relationship is defined), convert it to an array
+				if ($options['relationship'] AND is_a($model->$name, 'Illuminate\Database\Eloquent\Collection'))
 				{
 					$dataModel[$name] = $model->$name->toArray();
 				}


### PR DESCRIPTION
Hello,

A little fix for the Field Factory : when you try to get access to a non eloquent method of an object an eloquent exception is raised.

The reason ?

-> By default Field Factory try to check if all found methods are eloquent relations, wheras if it is a standard method it fail (Field Factory is calling the attribute name, it query the eloquent model to resolve to do an implicit relation on it and fails).

Solution ?

-> Simply try to resolve relations only when the option "relationship" is defined for the attribute.