### PR TITLE
Fetch default values for filter from the URL

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -1029,7 +1029,7 @@
 			
 			/**
 			 * Try to get the value of a parameter from the URL
-			 * Exmaple : ?foo=bar
+			 * Example : ?foo=bar
 			 *
 			 * @return string
 			 */

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -1026,6 +1026,17 @@
 		prepareFilters: function()
 		{
 			var filters = [];
+			
+			/**
+			 * Try to get the value of a parameter from the URL
+			 * Exmaple : ?foo=bar
+			 *
+			 * @return string
+			 */
+			var getURLParameter = function(name)
+			{
+				return decodeURIComponent((new RegExp('[?|&]' + name + '=' + '([^&;]+?)(&|#|;|$)').exec(location.search)||[,""])[1].replace(/\+/g, '%20'))||null
+			};
 
 			$.each(adminData.filters, function(ind, filter)
 			{
@@ -1047,6 +1058,8 @@
 				}
 
 				filter.field_id = 'filter_field_' + filter.field_name;
+				
+				filter.value(getURLParameter(filter.field_name));
 
 				filters.push(filter);
 			});


### PR DESCRIPTION
Hi,

I would like to be able to use URLs like `admin/users?lastname=ol` to immediately filter the view.

I don't really know where the `getURLParameter` function should be placed...

Before eventually merging this branch (if everything is fine) let me change the doc to inform users about this possibility.