### PR TITLE
Reset $visible when getting item info via AJAX

### DIFF
--- a/src/controllers/AdminController.php
+++ b/src/controllers/AdminController.php
@@ -81,6 +81,8 @@ class AdminController extends Controller {
 			{
 				$model = $config->updateModel($model, $fieldFactory, $actionFactory);
 			}
+			
+			$model->setVisible(array());
 
 			$response = $actionPermissions['view'] ? response()->json($model) : response()->json(array(
 				'success' => false,


### PR DESCRIPTION
Whether this is the best way to go about it I don't know, but there's a huge issue with the admin panel if you're using the $visible property on your models right now.

Simply put, because administrator_edit_fields, administrator_action_permissions and administrator_actions aren't visible due to the setting of the $visible array (unless you put them in) the admin refuses to allow the editing of existing rows. As detailed in #745

Unfortunately, Model doesn't have a getVisible(), so you can't really just append it AFAIK. Best thing to do seems to be to make everything visible while in the admin backend. At the end of the day if you're an admin you're going to be able to see this info anyway, if there's anything super important to keep hidden then add it to $hidden and it'll still be missing from the returned array.