### PR TITLE
Issue #775 Pass eloquent model to column "output" renderer.

### DIFF
--- a/src/Frozennode/Administrator/DataTable/Columns/Column.php
+++ b/src/Frozennode/Administrator/DataTable/Columns/Column.php
@@ -4,6 +4,7 @@ namespace Frozennode\Administrator\DataTable\Columns;
 use Frozennode\Administrator\Validator;
 use Frozennode\Administrator\Config\ConfigInterface;
 use Illuminate\Database\DatabaseManager as DB;
+use Illuminate\Database\Eloquent\Model;
 
 class Column {
 
@@ -245,7 +246,7 @@ class Column {
 	 *
 	 * @return string
 	 */
-	public function renderOutput($value, $item = null)
+	public function renderOutput($value, Model $item = null)
 	{
 		$output = $this->getOption('output');
 		

--- a/src/Frozennode/Administrator/DataTable/Columns/Column.php
+++ b/src/Frozennode/Administrator/DataTable/Columns/Column.php
@@ -240,16 +240,17 @@ class Column {
 	/**
 	 * Takes a column output string and renders the column with it (replacing '(:value)' with the column's field value)
 	 *
-	 * @param string	$value
+	 * @param $value string	$value
+	 * @param \Illuminate\Database\Eloquent\Model	$item
 	 *
 	 * @return string
 	 */
-	public function renderOutput($value)
+	public function renderOutput($value, $item = null)
 	{
 		$output = $this->getOption('output');
 		
 		if (is_callable($output)) {
-			return $output($value);
+			return $output($value, $item);
 		}
 		
 		return str_replace('(:value)', $value, $output);

--- a/src/Frozennode/Administrator/DataTable/Columns/Column.php
+++ b/src/Frozennode/Administrator/DataTable/Columns/Column.php
@@ -246,7 +246,7 @@ class Column {
 	 *
 	 * @return string
 	 */
-	public function renderOutput($value, Model $item = null)
+	public function renderOutput($value, $item = null)
 	{
 		$output = $this->getOption('output');
 		

--- a/src/Frozennode/Administrator/DataTable/DataTable.php
+++ b/src/Frozennode/Administrator/DataTable/DataTable.php
@@ -290,7 +290,7 @@ class DataTable {
 			{
 				$outputRow[$field] = array(
 					'raw' => $attributeValue,
-					'rendered' => $columns[$field]->renderOutput($attributeValue),
+					'rendered' => $columns[$field]->renderOutput($attributeValue, $item),
 				);
 			}
 			//otherwise it's likely the primary key column which wasn't included (though it's needed for identification purposes)
@@ -322,7 +322,7 @@ class DataTable {
 		{
 			$outputRow[$name] = array(
 				'raw' => $item->{$name},
-				'rendered' => $columns[$name]->renderOutput($item->{$name}),
+				'rendered' => $columns[$name]->renderOutput($item->{$name}, $item),
 			);
 		}
 	}


### PR DESCRIPTION
When rendering a column in the "columns" listing, the "output" closure is given a raw value, but nothing else. This change passes the eloquent model also to the closure, so other fields can be referenced.

Other fields may include, for example, the ID of the row, or the ID of a parent record, which will come in very handy to create links direct to parent records in the column listing.