### PR TITLE
global_rows_per_page cannot be NULL

### DIFF
--- a/src/config/administrator.php
+++ b/src/config/administrator.php
@@ -117,7 +117,7 @@ return array(
 	/**
 	 * Global default rows per page
 	 *
-	 * @type NULL|int
+	 * @type int
 	 */
 	'global_rows_per_page' => 20,
 


### PR DESCRIPTION
if this value is set to NULL, a 'division by zero' error is triggered in DataTable.php on line 203 (performCountQuery)
