### PR TITLE
Rename the Bool class to Boolean to fix php 7

### DIFF
--- a/src/Frozennode/Administrator/Fields/Boolean.php
+++ b/src/Frozennode/Administrator/Fields/Boolean.php
@@ -3,7 +3,7 @@ namespace Frozennode\Administrator\Fields;
 
 use Illuminate\Database\Query\Builder as QueryBuilder;
 
-class Bool extends Field {
+class Boolean extends Field {
 
 	/**
 	 * The value (used in filter)

--- a/src/Frozennode/Administrator/Fields/Factory.php
+++ b/src/Frozennode/Administrator/Fields/Factory.php
@@ -25,7 +25,7 @@ class Factory {
 		'time' => 'Frozennode\\Administrator\\Fields\\Time',
 		'datetime' => 'Frozennode\\Administrator\\Fields\\Time',
 		'number' => 'Frozennode\\Administrator\\Fields\\Number',
-		'bool' => 'Frozennode\\Administrator\\Fields\\Bool',
+		'bool' => 'Frozennode\\Administrator\\Fields\\Boolean',
 		'enum' => 'Frozennode\\Administrator\\Fields\\Enum',
 		'image' => 'Frozennode\\Administrator\\Fields\\Image',
 		'file' => 'Frozennode\\Administrator\\Fields\\File',

--- a/tests/Fields/BoolTest.php
+++ b/tests/Fields/BoolTest.php
@@ -42,7 +42,7 @@ class BoolTest extends \PHPUnit_Framework_TestCase {
 		$this->config = m::mock('Frozennode\Administrator\Config\Model\Config');
 		$this->db = m::mock('Illuminate\Database\DatabaseManager');
 		$options = array('field_name' => 'field', 'type' => 'bool');
-		$this->field = m::mock('Frozennode\Administrator\Fields\Bool', array($this->validator, $this->config, $this->db, $options))->makePartial();
+		$this->field = m::mock('Frozennode\Administrator\Fields\Boolean', array($this->validator, $this->config, $this->db, $options))->makePartial();
 	}
 
 	/**


### PR DESCRIPTION
 "Cannot use 'Bool' as class name as it is reserved".
All other PHPunit tests pass, except that Time field, but it seems to be broken on travis for a while on all php versions.