### PR TITLE
Bumping version to 5.0.5

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,15 @@
 ## Changelog
 
+### 5.0.5
+- Added: Added password field to the settings view
+- Added: Romanian Language
+- Added: Basic HasMany Implementation along with re-ordering support
+- Bugfix: Autocomplete working with default value
+- Bugfix: Adding missing session to Admin Controller
+- Bugfix: Fixed improper handling of filter value 0 for Enum/Text field
+- Docfix: Simplified the composer command in the install docs to match the packagist.org instuctions
+- Docfix: Changed the type definition for global_rows_per_page to int instead of Null|nt since Null causes divide by 0 error
+
 ### 5.0.4
 - Testfix: fixing tests and js for gulp
 

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -1134,6 +1134,17 @@
 			{
 				if (el.relationship)
 					self.viewModel.listOptions[ind] = el.options;
+
+				// add any loaded option to the autocomplete array
+				if (el.autocomplete)
+				{
+					if(! (el.field_name + '_autocomplete' in self.viewModel) )
+						self.viewModel[el.field_name + '_autocomplete'] = [];
+					$.each(el.options, function(x, option)
+					{
+						self.viewModel[el.field_name + '_autocomplete'][option.id] = option;	
+					});
+				}
 			});
 		},
 

--- a/public/js/knockout/custom-bindings.js
+++ b/public/js/knockout/custom-bindings.js
@@ -240,7 +240,10 @@
 					var data = [],
 						val = $(element).val();
 
-					if (!val)
+					// If the select2 field has a default value,
+					// initSelection will be called before the admin object
+					// is correctly initialized. 
+					if (!val || typeof admin === 'undefined')
 						return callback(null);
 
 					//if this is a multi-select, set up the data as an array
@@ -248,13 +251,15 @@
 					{
 						$(element.val().split(',')).each(function(ind, el)
 						{
-							data.push({id: this, text: admin.viewModel[options.field + '_autocomplete'][this].text});
+							if(this in admin.viewModel[options.field + '_autocomplete'])
+								data.push({id: this, text: admin.viewModel[options.field + '_autocomplete'][this].text});
 						});
 					}
 					//otherwise make the data a simple object
 					else
 					{
-						data = {id: val, text: admin.viewModel[options.field + '_autocomplete'][val].text};
+						if(val in admin.viewModel[options.field + '_autocomplete'])
+							data = {id: val, text: admin.viewModel[options.field + '_autocomplete'][val].text};
 					}
 
 					callback(data);

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@ Administrator is an administrative interface builder for [Laravel](http://larave
 
 - **Author:** Jan Hartigan
 - **Website:** [http://frozennode.com](http://administrator.frozennode.com/)
-- **Version:** 5.0.4
+- **Version:** 5.0.5
 
 [![Build Status](https://travis-ci.org/FrozenNode/Laravel-Administrator.png?branch=master)](https://travis-ci.org/FrozenNode/Laravel-Administrator)
 
@@ -62,6 +62,16 @@ Administrator is released under the MIT License. See the LICENSE file for detail
 
 
 ## Recent Changelog
+
+### 5.0.5
+- Added: Added password field to the settings view
+- Added: Romanian Language
+- Added: Basic HasMany Implementation along with re-ordering support
+- Bugfix: Autocomplete working with default value
+- Bugfix: Adding missing session to Admin Controller
+- Bugfix: Fixed improper handling of filter value 0 for Enum/Text field
+- Docfix: Simplified the composer command in the install docs to match the packagist.org instuctions
+- Docfix: Changed the type definition for global_rows_per_page to int instead of Null|nt since Null causes divide by 0 error
 
 ### 5.0.4
 - Testfix: fixing tests and js for gulp

--- a/readme.md
+++ b/readme.md
@@ -12,13 +12,13 @@ Administrator is an administrative interface builder for [Laravel](http://larave
 
 ## Composer
 
-To install Administrator as a Composer package to be used with Laravel 5, simply add this to your composer.json:
+To install Administrator as a Composer package to be used with Laravel 5, simply run:
 
-```json
-"frozennode/administrator": "5.*"
+```sh
+composer require "frozennode/administrator: 5.*"
 ```
 
-..and run `composer update`.  Once it's installed, you can register the service provider in `config/app.php` in the `providers` array:
+Once it's installed, you can register the service provider in `config/app.php` in the `providers` array:
 
 ```php
 'providers' => [

--- a/src/Frozennode/Administrator/Fields/Enum.php
+++ b/src/Frozennode/Administrator/Fields/Enum.php
@@ -77,7 +77,7 @@ class Enum extends Field {
 		parent::filterQuery($query, $selects);
 
 		//if there is no value, return
-		if (!$this->getOption('value'))
+		if ($this->getFilterValue($this->getOption('value'))===false)
 		{
 			return;
 		}

--- a/src/Frozennode/Administrator/Fields/Field.php
+++ b/src/Frozennode/Administrator/Fields/Field.php
@@ -223,7 +223,7 @@ abstract class Field {
 	 */
 	public function getFilterValue($value)
 	{
-		if (empty($value) || (is_string($value) && trim($value) === ''))
+		if (($value!==0 && $value!=='0' && empty($value)) || (is_string($value) && trim($value) === ''))
 		{
 			return false;
 		}

--- a/src/Frozennode/Administrator/Fields/Relationships/HasMany.php
+++ b/src/Frozennode/Administrator/Fields/Relationships/HasMany.php
@@ -1,6 +1,8 @@
 <?php
 namespace Frozennode\Administrator\Fields\Relationships;
 
+use Illuminate\Database\Query\Builder as QueryBuilder;
+
 class HasMany extends HasOneOrMany {
 
 	/**
@@ -9,7 +11,100 @@ class HasMany extends HasOneOrMany {
 	 * @var array
 	 */
 	protected $relationshipDefaults = array(
+		'column2' => '',
 		'multiple_values' => true,
-		'editable' => false,
+		'sort_field' => false,
 	);
+
+
+	/**
+	 * Fill a model with input data
+	 *
+	 * @param \Illuminate\Database\Eloquent\Model	$model
+	 * @param mixed									$input
+	 *
+	 * @return array
+	 */
+	public function fillModel(&$model, $input)
+	{
+		// $input is an array of all foreign key IDs
+		//
+		// $model is the model for which the above answers should be associated to
+		$fieldName = $this->getOption('field_name');
+		$input = $input ? explode(',', $input) : array();
+		$relationship = $model->{$fieldName}();
+
+		// get the plain foreign key so we can set it to null:
+		$fkey = $relationship->getPlainForeignKey();
+
+		$relatedObjectClass = get_class($relationship->getRelated());
+
+		// first we "forget all the related models" (by setting their foreign key to null)
+		foreach($relationship->get() as $related)
+		{
+			$related->$fkey = null; // disassociate
+			$related->save();
+		}
+
+		// now associate new ones: (setting the correct order as well)
+		$i = 0;
+		foreach($input as $foreign_id)
+		{
+			$relatedObject = call_user_func($relatedObjectClass .'::find', $foreign_id);
+			if ($sortField = $this->getOption('sort_field'))
+			{
+				$relatedObject->$sortField = $i++;
+			}
+
+			$relationship->save($relatedObject);
+		}
+	}
+
+
+	/**
+	 * Filters a query object with this item's data
+	 *
+	 * @param \Illuminate\Database\Query\Builder	$query
+	 * @param array									$selects
+	 *
+	 * @return void
+	 */
+	public function filterQuery(QueryBuilder &$query, &$selects = null)
+	{
+		//run the parent method
+		parent::filterQuery($query, $selects);
+
+		//get the values
+		$value = $this->getOption('value');
+		$table = $this->getOption('table');
+		$column = $this->getOption('column');
+		$column2 = $this->getOption('column2');
+
+		//if there is no value, return
+		if (!$value)
+		{
+			return;
+		}
+
+		$model = $this->config->getDataModel();
+
+		//if the table hasn't been joined yet, join it
+		if (!$this->validator->isJoined($query, $table))
+		{
+			$query->join($table, $model->getTable().'.'.$model->getKeyName(), '=', $column);
+		}
+
+		//add where clause
+		$query->whereIn($column2, $value);
+
+		//add having clauses
+		$query->havingRaw('COUNT(DISTINCT ' . $query->getConnection()->getTablePrefix() . $column2 . ') = ' . count($value));
+
+		//add select field
+		if ($selects && !in_array($column2, $selects))
+		{
+			$selects[] = $column2;
+		}
+	}
+
 }

--- a/src/Frozennode/Administrator/Fields/Relationships/Relationship.php
+++ b/src/Frozennode/Administrator/Fields/Relationships/Relationship.php
@@ -154,6 +154,12 @@ abstract class Relationship extends Field {
 		else if ($relationshipItems = $relationship->get())
 		{
 			$items = $relationshipItems;
+
+			// if no related items exist, add default item, if set in options
+			if (count($items) == 0 && array_key_exists('value', $options))
+			{
+				$items = $relatedModel->where($relatedModel->getKeyName(), '=', $options['value'])->get();
+			}
 		}
 
 		//map the options to the options property where array('id': [key], 'text': [nameField])

--- a/src/Frozennode/Administrator/Fields/Text.php
+++ b/src/Frozennode/Administrator/Fields/Text.php
@@ -39,7 +39,7 @@ class Text extends Field {
 		parent::filterQuery($query, $selects);
 
 		//if there is no value, return
-		if (!$this->getOption('value'))
+		if ($this->getFilterValue($this->getOption('value'))===false)
 		{
 			return;
 		}

--- a/src/config/administrator.php
+++ b/src/config/administrator.php
@@ -117,7 +117,7 @@ return array(
 	/**
 	 * Global default rows per page
 	 *
-	 * @type NULL|int
+	 * @type int
 	 */
 	'global_rows_per_page' => 20,
 

--- a/src/controllers/AdminController.php
+++ b/src/controllers/AdminController.php
@@ -33,6 +33,7 @@ class AdminController extends Controller {
 	public function __construct(Request $request, Session $session)
 	{
 		$this->request = $request;
+		$this->session = $session;
 
 		if ( ! is_null($this->layout))
 		{

--- a/src/lang/ro/administrator.php
+++ b/src/lang/ro/administrator.php
@@ -1,0 +1,57 @@
+<?php
+
+return array(
+
+	/*
+	|--------------------------------------------------------------------------
+	| Administrator Language Lines
+	|--------------------------------------------------------------------------
+	|
+	| ro - Română
+	|
+	*/
+
+	'dashboard' => 'Panou control',
+	'edit' => 'Editează',
+	'filters' => 'Filtre',
+	'loading' => 'Se încarcă...',
+	'createnew' => 'Adaugă',
+	'new' => 'Adaugă',
+	'viewitem' => 'Vezi :single',
+	'id' => 'ID',
+	'uploadimage' => 'Încarcă imagine',
+	'imageuploading' => 'Imaginea se încarcă',
+	'uploadfile' => 'Încarcă Fișier',
+	'fileuploading' => 'Fișierul se încarcă',
+	'no_image_uploaded' => 'Nicio imagine încarcată',
+	'no_file_uploaded' => 'Niciun fișier încarcat',
+	'none' => 'Nimic',
+	'all' => 'Toate',
+	'itemsperpage' => 'înregistrări pe pagină',
+	'noresults' => 'Fără rezultate',
+	'backtosite' => 'Înapoi la Site',
+	'logout' => 'Logout',
+
+	'previous' => 'anterioara',
+	'next' => 'următoarea',
+
+	'close' => 'Închide',
+	'delete' => 'Șterge',
+	'save' => 'Salvează',
+	'create' => 'Creează',
+	'cancel' => 'Anulează',
+
+	'active' => 'Un moment...',
+	'success' => 'Succes!',
+	'error' => 'A apărut o eroare în execuția acestei acțiuni',
+
+	'valid_columns' => "You must provide a valid 'columns' array in each model's config",
+	'valid_title' => "You must provide a valid title and single name in each model's config",
+	'valid_model' => "You must provide a 'model' option in each model's config",
+	'valid_edit' => "You must provide a valid 'edit_fields' array in each model's config",
+	'valid_menu' => "You must provide a valid 'menu' option in the administrator.php config",
+	'valid_config_path' => "You must provide a valid 'model_config_path' in the administrator.php config. The directory must also exist and be readable.",
+	'not_eloquent' => " is not an Eloquent model",
+	'storage_path_permissions' => "You must make your storage path writable in order to make a settings page",
+	'valid_home_page' => "You must provide a valid menu item in the home_page option of your config",
+);

--- a/src/lang/ro/knockout.php
+++ b/src/lang/ro/knockout.php
@@ -1,0 +1,24 @@
+<?php 
+
+return array(
+
+	/*
+	|--------------------------------------------------------------------------
+	| Administrator Language Lines for knockout
+	|--------------------------------------------------------------------------
+	|
+	| ro - Română
+	|
+	*/
+
+	'delete_active_item' => 'Doriți să ștergeți acestă înregistrare? Operația este ireversibilă.',
+	'saving' => 'Se salvează...',
+	'saved' => 'Înregistrare salvată.',
+	'deleting' => 'Se șterge...',
+	'deleted' => 'Înregistrare ștearsă.',
+	'character_left' => ' caracter rămas',
+	'characters_left' => ' caractere rămase',
+	'no_results' => 'Nu a fost găsit nici un rezultat',
+	'select_options' => 'Selectați',
+
+);

--- a/src/views/templates/edit.php
+++ b/src/views/templates/edit.php
@@ -115,6 +115,26 @@
 				<!-- /ko -->
 			<!-- /ko -->
 
+			<!-- ko if: type === 'has_many' -->
+				<!-- ko if: loadingOptions -->
+					<div class="loader"></div>
+				<!-- /ko -->
+
+				<!-- ko if: autocomplete -->
+				<input type="hidden" data-bind="attr: {disabled: $root.freezeForm() || loadingOptions() || constraintLoading() || !editable,
+														id: field_id},
+									select2Remote: {field: field_name, type: 'edit', multiple: true, constraints: constraints, sort: sort_field},
+									value: $root[field_name]" />
+				<!-- /ko -->
+
+				<!-- ko ifnot: autocomplete -->
+				<input type="hidden" data-bind="attr: {disabled: $root.freezeForm() || loadingOptions() || constraintLoading() || !editable,
+														id: field_id},
+													select2: {data:{results: $root.listOptions[field_name]}, multiple: true, sort: sort_field},
+													value: $root[field_name]" />
+				<!-- /ko -->
+			<!-- /ko -->
+
 			<!-- ko if: type === 'number' -->
 				<!-- ko if: editable -->
 					<span class="symbol" data-bind="text: symbol"></span>

--- a/src/views/templates/settings.php
+++ b/src/views/templates/settings.php
@@ -48,6 +48,17 @@
 				<!-- /ko -->
 			<!-- /ko -->
 
+            <!-- ko if: type === 'password' -->
+                <!-- ko if: editable -->
+                    <div class="characters_left" data-bind="charactersLeft: {value: $root[field_name], limit: limit}"></div>
+                    <input type="password" data-bind="attr: {disabled: $root.freezeForm, id: field_id}, value: $root[field_name],
+                                                valueUpdate: 'afterkeydown', characterLimit: limit" />
+                <!-- /ko -->
+                <!-- ko ifnot: editable -->
+                    <div class="uneditable" data-bind="text: '********'"></div>
+                <!-- /ko -->
+            <!-- /ko -->
+
 			<!-- ko if: type === 'number' -->
 				<!-- ko if: editable -->
 					<span class="symbol" data-bind="text: symbol"></span>


### PR DESCRIPTION
Version 5.0.5

    Added: Added password field to the settings view
    Added: Romanian Language
    Added: Basic HasMany Implementation along with re-ordering support
    Bugfix: Autocomplete working with default value
    Bugfix: Adding missing session to Admin Controller
    Bugfix: Fixed improper handling of filter value 0 for Enum/Text field
    Docfix: Simplified the composer command in the install docs to match the packagist.org instuctions
    Docfix: Changed the type definition for global_rows_per_page to int instead of Null|nt since Null causes divide by 0 error
