### PR TITLE
Added option random_cb for images in edit fields

### DIFF
--- a/docs/field-type-image.md
+++ b/docs/field-type-image.md
@@ -32,6 +32,8 @@ The optional `naming` option lets you define whether to `keep` the file's name o
 
 The optional `length` option lets you define size of file name in case `random` is supplied as `naming` option method.
 
+The optional `random_cb` option lets you provide a callback to generate random names for images. The callback receives three parameters : the original file name, an instance of `Symfony\Component\HttpFoundation\File\UploadedFile` and the `length` option provided. The callback must return the desired file name.
+
 The optional `size_limit` option lets you set an integer size limit counted in megabytes. This only affects the JavaScript file uploading dialog, it doesn't limit your PHP upload sizes.
 
 The optional `display_raw_value` option lets you put the raw value of the saved image source string into the image input. This is useful if you're using accessors, mutators, and [`setter fields`](/docs/fields#setter-option) to skip storing the image on your local server and instead upload it to a remote public image server.

--- a/src/Frozennode/Administrator/Fields/Image.php
+++ b/src/Frozennode/Administrator/Fields/Image.php
@@ -11,6 +11,7 @@ class Image extends File {
 	 * @var array
 	 */
 	protected $imageDefaults = array(
+		'random_cb' => null,
 		'sizes' => array(),
 	);
 
@@ -20,6 +21,7 @@ class Image extends File {
 	 * @var array
 	 */
 	protected $imageRules = array(
+		'random_cb' => 'callable',
 		'sizes' => 'array',
 	);
 
@@ -35,6 +37,7 @@ class Image extends File {
 									$this->getOption('naming') === 'random')
 			->sizes($this->getOption('sizes'))
 			->set_length($this->getOption('length'))
+			->filename_callback($this->getOption('random_cb'))
 			->upload();
 
 		return $result[0];

--- a/src/Frozennode/Administrator/Includes/Multup.php
+++ b/src/Frozennode/Administrator/Includes/Multup.php
@@ -195,7 +195,9 @@ class Multup {
 
 			if($this->random){
 				if(is_callable($this->random_cb)){
-					$filename =  call_user_func( $this->random_cb, $original_name );
+					$filename =  call_user_func($this->random_cb, $original_name,
+                                                    $this->image[$this->input],
+                                                    $this->random_length);
 				} else {
 					$ext = File::extension($original_name);
 					$filename = $this->generate_random_filename().'.'.$ext;


### PR DESCRIPTION
Hi,

this is a small addition to let the developer generate image names. 

I wanted to add a `function` possible value to the `naming` option and add a `naming_cb` option, but this requires some refactoring to keep the code clean*. 

So, this just adds the possibility to provide a callback, but it is of-course not mandatory for the callback to provide actual-random names. (md5 of the file content is what I personnally do !).

Also if you like this and would rather set the defaults-options/rules in the `Field\File` class, just tell me.

(* I wish that `Multup` does not generate names by itself, only using the callbacks it's given or a name (string) it's given.)