### PR TITLE
Added Dynamic Form Request validation support to the Admin Controller

### DIFF
--- a/docs/fields.md
+++ b/docs/fields.md
@@ -118,7 +118,7 @@ The `setter` option lets you define a field as an attribute that is set on the E
 <a name="form-request-option"></a>
 ## Form Request Option
 
-The `form request` option lets you define a custom [form request](http://laravel.com/docs/validation#form-request-validation) to validate the editable fields on save. This field is optional by default.
+The `form request` option lets you define a custom [form request](http://laravel.com/docs/validation#form-request-validation) to validate the editable fields on save. The Form Request object must contain a rules array to validate. This field is optional by default.
 
 	'form_request' => 'FormRequestPath',
 

--- a/docs/fields.md
+++ b/docs/fields.md
@@ -5,6 +5,7 @@
 - [Type Option](#type-option)
 - [Editable Option](#editable-option)
 - [Setter Option](#setter-option)
+- [Form Request Option](#form-request-option)
 - [Visible Option](#visible-option)
 - [Value Option](#value-option)
 - [Description Option](#description-option)
@@ -113,6 +114,13 @@ The `setter` option lets you define a field as an attribute that is set on the E
 		'title' => 'Name',
 		'setter' => true,
 	),
+	
+<a name="form-request-option"></a>
+## Form Request Option
+
+The `form request` option lets you define a custom [form request](http://laravel.com/docs/validation#form-request-validation) to validate the editable fields on save. This field is optional by default.
+
+	'form_request' => 'FormRequestPath',
 
 <a name="visible-option"></a>
 ## Visible Option

--- a/src/Frozennode/Administrator/Config/Model/Config.php
+++ b/src/Frozennode/Administrator/Config/Model/Config.php
@@ -544,4 +544,27 @@ class Config extends ConfigBase implements ConfigInterface {
 			$filter($query);
 		}
 	}
+	
+	/**
+	 * Fetches the data model for a config given a post input array
+	 *
+	 * @param \Illuminate\Http\Request $input
+	 * @param array	                   $fields
+	 * @param int                      $id
+	 *
+	 * @return \Illuminate\Database\Eloquent\Model
+	 */
+	public function getFilledDataModel(\Illuminate\Http\Request $input, array $fields, $id = 0)
+	{
+		$model = $this->getDataModel();
+
+		if ($id)
+		{
+			$model = $model->find($id);
+		}
+
+		$this->fillModel($model, $input, $fields);
+
+		return $model;
+	}
 }

--- a/src/controllers/AdminController.php
+++ b/src/controllers/AdminController.php
@@ -25,7 +25,7 @@ class AdminController extends Controller {
 	/**
 	 * @var string
 	 */
-	protected $requestErrors;
+	protected $formRequestErrors;
 
 	/**
 	 * @var string
@@ -41,7 +41,7 @@ class AdminController extends Controller {
 		$this->request = $request;
 		$this->session = $session;
 		
-		$this->requestErrors = $this->resolveDynamicRequestErrors();
+		$this->formRequestErrors = $this->resolveDynamicFormRequestErrors();
 
 		if ( ! is_null($this->layout))
 		{
@@ -126,10 +126,10 @@ class AdminController extends Controller {
 		$fieldFactory = app('admin_field_factory');
 		$actionFactory = app('admin_action_factory');
 		
-		if (array_key_exists('request', $config->getOptions()) && $this->requestErrors !== null) {
+		if (array_key_exists('form_request', $config->getOptions()) && $this->formRequestErrors !== null) {
 			return response()->json(array(
 				'success' => false,
-				'errors'  => $this->requestErrors,
+				'errors'  => $this->formRequestErrors,
 			));
 		}
 		
@@ -634,18 +634,18 @@ class AdminController extends Controller {
 	}
 
 	/**
-	 * POST method for any request errors
+	 * POST method to capture any form request errors
 	 */
-	protected function resolveDynamicRequestErrors()
+	protected function resolveDynamicFormRequestErrors()
 	{
 		try {
 			$config = app('itemconfig');
 		} catch (\ReflectionException $e) {
 			return null;
 		}
-		if (array_key_exists('request', $config->getOptions())) {
+		if (array_key_exists('form_request', $config->getOptions())) {
 			try {
-				app($config->getOptions()['request']);
+				app($config->getOptions()['form_request']);
 			} catch (HttpResponseException $e) {
 				//Parses the exceptions thrown by Illuminate\Foundation\Http\FormRequest
 				$errorsArray = json_decode($e->getResponse()->getContent());

--- a/src/controllers/AdminController.php
+++ b/src/controllers/AdminController.php
@@ -41,7 +41,7 @@ class AdminController extends Controller {
 		$this->request = $request;
 		$this->session = $session;
 		
-		$this->formRequestErrors = $this->resolveDynamicFormRequestErrors();
+		$this->formRequestErrors = $this->resolveDynamicFormRequestErrors($request);
 
 		if ( ! is_null($this->layout))
 		{
@@ -635,8 +635,10 @@ class AdminController extends Controller {
 
 	/**
 	 * POST method to capture any form request errors
+	 *
+	 * @param \Illuminate\Http\Request $request
 	 */
-	protected function resolveDynamicFormRequestErrors()
+	protected function resolveDynamicFormRequestErrors(Request $request)
 	{
 		try {
 			$config = app('itemconfig');

--- a/src/controllers/AdminController.php
+++ b/src/controllers/AdminController.php
@@ -648,7 +648,11 @@ class AdminController extends Controller {
 				app($config->getOptions()['form_request']);
 			} catch (HttpResponseException $e) {
 				//Parses the exceptions thrown by Illuminate\Foundation\Http\FormRequest
-				$errorsArray = json_decode($e->getResponse()->getContent());
+				$errorMessages = $e->getResponse()->getContent();
+				if (is_string ( $errorMessages )) {
+					return $errorMessages;
+				}
+				$errorsArray = json_decode($errorMessages);
 				if ($errorsArray) {
 					return implode(".", array_dot($errorsArray));
 				}

--- a/src/controllers/AdminController.php
+++ b/src/controllers/AdminController.php
@@ -645,7 +645,7 @@ class AdminController extends Controller {
 		}
 		if (array_key_exists('form_request', $config->getOptions())) {
 			try {
-				app($config->getOptions()['form_request']);
+				app($config->getOption('form_request'));
 			} catch (HttpResponseException $e) {
 				//Parses the exceptions thrown by Illuminate\Foundation\Http\FormRequest
 				$errorMessages = $e->getResponse()->getContent();


### PR DESCRIPTION
Added Optional Dynamic Form Request validation support on save. 

The validation takes place on construct since by the save, the session no longer has the form submission. If error(s) exist and the request is a save, then the messages are passed back in the same way all other errors are returned. This supports both authorize and rules errors. 