### PR TITLE
Fixed boolean true bug

### DIFF
--- a/src/Frozennode/Administrator/Fields/Bool.php
+++ b/src/Frozennode/Administrator/Fields/Bool.php
@@ -38,7 +38,7 @@ class Bool extends Field {
 	 */
 	public function fillModel(&$model, $input)
 	{
-		$model->{$this->getOption('field_name')} = $input === 'true' || $input === '1' ? 1 : 0;
+		$model->{$this->getOption('field_name')} = $input === 'true' || $input === '1' || $input === true ? 1 : 0;
 	}
 
 	/**


### PR DESCRIPTION
Fixed issue where when an input field of true has already been loaded into memory (such as through a form request), it resolves as boolean true instead of 'true'. This in turn causes the fillModel to resolve to false instead of true