### PR TITLE
Refactored FQDN to use relative paths

### DIFF
--- a/src/Frozennode/Administrator/Fields/File.php
+++ b/src/Frozennode/Administrator/Fields/File.php
@@ -42,7 +42,7 @@ class File extends Field {
 		$route = $this->config->getType() === 'settings' ? 'admin_settings_file_upload' : 'admin_file_upload';
 
 		//set the upload url to the proper route
-		$this->suppliedOptions['upload_url'] = $url->route($route, array($this->config->getOption('name'), $this->suppliedOptions['field_name']));
+		$this->suppliedOptions['upload_url'] = $url->route($route, array($this->config->getOption('name'), $this->suppliedOptions['field_name']), false);
 	}
 
 	/**

--- a/src/Frozennode/Administrator/Http/Middleware/PostValidate.php
+++ b/src/Frozennode/Administrator/Http/Middleware/PostValidate.php
@@ -27,7 +27,7 @@ class PostValidate {
 		//if the user is simply not allowed permission to this model, redirect them to the dashboard
 		if (!$p)
 		{
-			return redirect()->route('admin_dashboard');
+			return redirect()->route('admin_dashboard', [], false);
 		}
 
 		//get the settings data if it's a settings page

--- a/src/Frozennode/Administrator/Http/Middleware/ValidateAdmin.php
+++ b/src/Frozennode/Administrator/Http/Middleware/ValidateAdmin.php
@@ -21,7 +21,7 @@ class ValidateAdmin {
 		//if this is a simple false value, send the user to the login redirect
 		if (!$response = $permission())
 		{
-			$loginUrl = url(config('administrator.login_path', 'user/login'));
+			$loginUrl = '/'.trim(config('administrator.login_path', 'user/login'), '/');
 			$redirectKey = config('administrator.login_redirect_key', 'redirect');
 			$redirectUri = $request->url();
 

--- a/src/controllers/AdminController.php
+++ b/src/controllers/AdminController.php
@@ -21,7 +21,7 @@ class AdminController extends Controller {
 	 * @var \Illuminate\Session\SessionManager
 	 */
 	protected $session;
-	
+
 	/**
 	 * @var string
 	 */
@@ -40,7 +40,7 @@ class AdminController extends Controller {
 	{
 		$this->request = $request;
 		$this->session = $session;
-		
+
 		$this->formRequestErrors = $this->resolveDynamicFormRequestErrors($request);
 
 		if ( ! is_null($this->layout))
@@ -125,14 +125,14 @@ class AdminController extends Controller {
 		$config = app('itemconfig');
 		$fieldFactory = app('admin_field_factory');
 		$actionFactory = app('admin_action_factory');
-		
+
 		if (array_key_exists('form_request', $config->getOptions()) && $this->formRequestErrors !== null) {
 			return response()->json(array(
 				'success' => false,
 				'errors'  => $this->formRequestErrors,
 			));
 		}
-		
+
 		$save = $config->save($this->request, $fieldFactory->getEditFields(), $actionFactory->getActionPermissions(), $id);
 
 		if (is_string($save))
@@ -253,7 +253,7 @@ class AdminController extends Controller {
 				$headers = $result->headers->all();
 				$this->session->put('administrator_download_response', array('file' => $file, 'headers' => $headers));
 
-				$response['download'] = route('admin_file_download');
+				$response['download'] = route('admin_file_download', [], false);
 			}
 			//if it's a redirect, put the url into the redirect key so that javascript can transfer the user
 			else if (is_a($result, '\Illuminate\Http\RedirectResponse'))
@@ -320,7 +320,7 @@ class AdminController extends Controller {
 				$headers = $result->headers->all();
 				$this->session->put('administrator_download_response', array('file' => $file, 'headers' => $headers));
 
-				$response['download'] = route('admin_file_download');
+				$response['download'] = route('admin_file_download', [], false);
 			}
 			//if it's a redirect, put the url into the redirect key so that javascript can transfer the user
 			else if (is_a($result, '\Illuminate\Http\RedirectResponse'))
@@ -365,11 +365,11 @@ class AdminController extends Controller {
 			}
 			else if ($config->getType() === 'model')
 			{
-				return redirect()->route('admin_index', array($config->getOption('name')));
+				return redirect()->route('admin_index', array($config->getOption('name')), false);
 			}
 			else if ($config->getType() === 'settings')
 			{
-				return redirect()->route('admin_settings', array($config->getOption('name')));
+				return redirect()->route('admin_settings', array($config->getOption('name')), false);
 			}
 		}
 	}
@@ -604,7 +604,7 @@ class AdminController extends Controller {
 				$headers = $result->headers->all();
 				$this->session->put('administrator_download_response', array('file' => $file, 'headers' => $headers));
 
-				$response['download'] = route('admin_file_download');
+				$response['download'] = route('admin_file_download', [], false);
 			}
 			//if it's a redirect, put the url into the redirect key so that javascript can transfer the user
 			else if (is_a($result, '\Illuminate\Http\RedirectResponse'))

--- a/src/viewComposers.php
+++ b/src/viewComposers.php
@@ -12,7 +12,7 @@ View::composer('administrator::index', function($view)
 	$actionFactory = app('admin_action_factory');
 	$dataTable = app('admin_datatable');
 	$model = $config->getDataModel();
-	$baseUrl = route('admin_dashboard');
+	$baseUrl = route('admin_dashboard', [], false);
 	$route = parse_url($baseUrl);
 
 	//add the view fields
@@ -30,7 +30,7 @@ View::composer('administrator::index', function($view)
 	$view->rows = $dataTable->getRows(app('db'), $view->filters);
 	$view->formWidth = $config->getOption('form_width');
 	$view->baseUrl = $baseUrl;
-	$view->assetUrl = url('packages/frozennode/administrator/');
+	$view->assetUrl = '/'.trim('packages/frozennode/administrator/', '/');
 	$view->route = $route['path'].'/';
 	$view->itemId = isset($view->itemId) ? $view->itemId : null;
 });
@@ -41,7 +41,7 @@ View::composer('administrator::settings', function($view)
 	$config = app('itemconfig');
 	$fieldFactory = app('admin_field_factory');
 	$actionFactory = app('admin_action_factory');
-	$baseUrl = route('admin_dashboard');
+	$baseUrl = route('admin_dashboard', [], false);
 	$route = parse_url($baseUrl);
 
 	//add the view fields
@@ -50,7 +50,7 @@ View::composer('administrator::settings', function($view)
 	$view->arrayFields = $fieldFactory->getEditFieldsArrays();
 	$view->actions = $actionFactory->getActionsOptions();
 	$view->baseUrl = $baseUrl;
-	$view->assetUrl = url('packages/frozennode/administrator/');
+	$view->assetUrl = '/'.trim('packages/frozennode/administrator/', '/');
 	$view->route = $route['path'].'/';
 });
 

--- a/src/views/index.php
+++ b/src/views/index.php
@@ -6,11 +6,11 @@
 </div>
 
 <script type="text/javascript">
-	var site_url = "<?php echo url('/') ?>",
+	var site_url = "<?php echo '/' ?>",
 		base_url = "<?php echo $baseUrl ?>/",
 		asset_url = "<?php echo $assetUrl ?>",
-		file_url = "<?php echo route('admin_display_file', array($config->getOption('name'))) ?>",
-		rows_per_page_url = "<?php echo route('admin_rows_per_page', array($config->getOption('name'))) ?>",
+		file_url = "<?php echo route('admin_display_file', array($config->getOption('name')), false) ?>",
+		rows_per_page_url = "<?php echo route('admin_rows_per_page', array($config->getOption('name')), false) ?>",
 		route = "<?php echo $route ?>",
 		csrf = "<?php echo csrf_token() ?>",
 		language = "<?php echo config('app.locale') ?>",

--- a/src/views/partials/header.blade.php
+++ b/src/views/partials/header.blade.php
@@ -1,6 +1,6 @@
 <header>
 	<h1>
-		<a href="{{route('admin_dashboard')}}">{{config('administrator.title')}}</a>
+		<a href="{{route('admin_dashboard', [], false)}}">{{config('administrator.title')}}</a>
 	</h1>
 
 	<a href="#" id="menu_button"><div></div></a>
@@ -29,7 +29,7 @@
 							@foreach (config('administrator.locales') as $lang)
 								@if (config('app.locale') != $lang)
 									<li>
-										<a href="{{route('admin_switch_locale', array($lang))}}">{{$lang}}</a>
+										<a href="{{route('admin_switch_locale', array($lang), false)}}">{{$lang}}</a>
 									</li>
 								@endif
 							@endforeach
@@ -38,9 +38,9 @@
 				</li>
 			</ul>
 		@endif
-		<a href="{{url(config('administrator.back_to_site_path', '/'))}}" id="back_to_site">{{trans('administrator::administrator.backtosite')}}</a>
+		<a href="{{'/'.trim(config('administrator.back_to_site_path'), '/')}}" id="back_to_site">{{trans('administrator::administrator.backtosite')}}</a>
 		@if(config('administrator.logout_path'))
-			<a href="{{url(config('administrator.logout_path'))}}" id="logout">{{trans('administrator::administrator.logout')}}</a>
+			<a href="{{'/'.trim(config('administrator.logout_path'), '/')}}" id="logout">{{trans('administrator::administrator.logout')}}</a>
 		@endif
 	</div>
 </header>

--- a/src/views/partials/menu_item.blade.php
+++ b/src/views/partials/menu_item.blade.php
@@ -15,11 +15,11 @@
 @else
 	<li class="item">
 		@if (strpos($key, $settingsPrefix) === 0)
-			<a href="{{route('admin_settings', array(substr($key, strlen($settingsPrefix))))}}">{{$item}}</a>
+			<a href="{{route('admin_settings', array(substr($key, strlen($settingsPrefix))), false)}}">{{$item}}</a>
 		@elseif (strpos($key, $pagePrefix) === 0)
-			<a href="{{route('admin_page', array(substr($key, strlen($pagePrefix))))}}">{{$item}}</a>
+			<a href="{{route('admin_page', array(substr($key, strlen($pagePrefix))), false)}}">{{$item}}</a>
 		@else
-			<a href="{{route('admin_index', array($key))}}">{{$item}}</a>
+			<a href="{{route('admin_index', array($key), false)}}">{{$item}}</a>
 		@endif
 	</li>
 @endif

--- a/src/views/settings.php
+++ b/src/views/settings.php
@@ -3,12 +3,12 @@
 </div>
 
 <script type="text/javascript">
-	var site_url = "<?php echo url() ?>",
+	var site_url = "<?php echo '/' ?>",
 		base_url = "<?php echo $baseUrl ?>/",
 		asset_url = "<?php echo $assetUrl ?>",
-		save_url = "<?php echo route('admin_settings_save', array($config->getOption('name'))) ?>",
-		custom_action_url = "<?php echo route('admin_settings_custom_action', array($config->getOption('name'))) ?>",
-		file_url = "<?php echo route('admin_settings_display_file', array($config->getOption('name'))) ?>",
+		save_url = "<?php echo route('admin_settings_save', array($config->getOption('name')), false) ?>",
+		custom_action_url = "<?php echo route('admin_settings_custom_action', array($config->getOption('name')), false) ?>",
+		file_url = "<?php echo route('admin_settings_display_file', array($config->getOption('name')), false) ?>",
 		route = "<?php echo $route ?>",
 		csrf = "<?php echo csrf_token() ?>",
 		language = "<?php echo config('app.locale') ?>",


### PR DESCRIPTION
Refactored FQDN's to use relative paths. This will fix possible bugs on mobile apps where the FQDN opens a link in the browser instead of remaining in the app