### PR TITLE
Added the table name to the constraint query

### DIFF
--- a/src/Frozennode/Administrator/Fields/Relationships/BelongsToMany.php
+++ b/src/Frozennode/Administrator/Fields/Relationships/BelongsToMany.php
@@ -138,6 +138,6 @@ class BelongsToMany extends Relationship {
 			$query->join($this->getOption('table'), $relatedModel->getTable().'.'.$relatedModel->getKeyName(), '=', $this->getOption('column2'));
 		}
 
-		$query->where($this->getOption('column'), '=', $constraint);
+		$query->where($this->getOption('table').'.'.$this->getOption('column'), '=', $constraint);
 	}
 }

--- a/src/Frozennode/Administrator/Fields/Relationships/HasOneOrMany.php
+++ b/src/Frozennode/Administrator/Fields/Relationships/HasOneOrMany.php
@@ -64,6 +64,6 @@ class HasOneOrMany extends Relationship {
 	 */
 	public function constrainQuery(EloquentBuilder &$query, $relatedModel, $constraint)
 	{
-		$query->where($this->getOption('column'), '=', $constraint);
+		$query->where($this->getOption('table').'.'.$this->getOption('column'), '=', $constraint);
 	}
 }

--- a/tests/Fields/Relationships/BelongsToManyTest.php
+++ b/tests/Fields/Relationships/BelongsToManyTest.php
@@ -154,7 +154,7 @@ class BelongsToManyTest extends \PHPUnit_Framework_TestCase {
 				->shouldReceive('where')->once();
 		$this->validator->shouldReceive('isJoined')->once();
 		$model = m::mock(array('getTable' => 'table', 'getKeyName' => 'id'));
-		$this->field->shouldReceive('getOption')->times(4);
+		$this->field->shouldReceive('getOption')->times(5);
 		$this->field->constrainQuery($query, $model, 'foo');
 	}
 

--- a/tests/Fields/Relationships/BelongsToManyTest.php
+++ b/tests/Fields/Relationships/BelongsToManyTest.php
@@ -165,7 +165,7 @@ class BelongsToManyTest extends \PHPUnit_Framework_TestCase {
 				->shouldReceive('where')->once();
 		$this->validator->shouldReceive('isJoined')->once()->andReturn(true);
 		$model = m::mock(array('getTable' => 'table', 'getKeyName' => 'id'));
-		$this->field->shouldReceive('getOption')->twice();
+		$this->field->shouldReceive('getOption')->times(3);
 		$this->field->constrainQuery($query, $model, 'foo');
 	}
 

--- a/tests/Fields/Relationships/HasOneOrManyTest.php
+++ b/tests/Fields/Relationships/HasOneOrManyTest.php
@@ -70,7 +70,7 @@ class HasOneOrManyTest extends \PHPUnit_Framework_TestCase {
 	{
 		$query = m::mock('Illuminate\Database\Eloquent\Builder');
 		$query->shouldReceive('where')->once();
-		$this->field->shouldReceive('getOption')->once();
+		$this->field->shouldReceive('getOption')->twice();
 		$this->field->constrainQuery($query, m::mock(array()), 'foo');
 	}
 }


### PR DESCRIPTION
This fixes an issue where joins in filters break constraints with ambiguous table names. 