### PR TITLE
Fixed bugs in filtering and editing fields in relationship

### DIFF
--- a/src/Frozennode/Administrator/Config/Model/Config.php
+++ b/src/Frozennode/Administrator/Config/Model/Config.php
@@ -186,7 +186,9 @@ class Config extends ConfigBase implements ConfigInterface {
 			//iterate over the items
 			foreach ($relatedItems as $item)
 			{
-				$keyName = $item->getKeyName();
+				// Modified. If this is set to 'keyName', it will not get foriegn key correctly
+				$keyName = $field->getOption('column');
+				// $keyName = $item->getKeyName();
 
 				//if this is a mutliple-value type (i.e. HasMany, BelongsToMany), make sure this is an array
 				if ($multipleValues)
@@ -544,7 +546,7 @@ class Config extends ConfigBase implements ConfigInterface {
 			$filter($query);
 		}
 	}
-	
+
 	/**
 	 * Fetches the data model for a config given a post input array
 	 *

--- a/src/Frozennode/Administrator/Fields/Relationships/BelongsTo.php
+++ b/src/Frozennode/Administrator/Fields/Relationships/BelongsTo.php
@@ -28,7 +28,9 @@ class BelongsTo extends Relationship {
 		$relatedModel = $relationship->getRelated();
 
 		$options['table'] = $relatedModel->getTable();
-		$options['column'] = $relatedModel->getKeyName();
+
+		// Assign foreign key value to column, instead of primary key
+		$options['column'] = $relatedModel->getOtherKey();
 		$options['foreign_key'] = $relationship->getForeignKey();
 
 		$this->suppliedOptions = $options;

--- a/src/Frozennode/Administrator/Fields/Relationships/Relationship.php
+++ b/src/Frozennode/Administrator/Fields/Relationships/Relationship.php
@@ -158,13 +158,15 @@ abstract class Relationship extends Field {
 			// if no related items exist, add default item, if set in options
 			if (count($items) == 0 && array_key_exists('value', $options))
 			{
-				$items = $relatedModel->where($relatedModel->getKeyName(), '=', $options['value'])->get();
+				$items = $relatedModel->where($relationship->getOtherKey(), '=', $options['value'])->get();
 			}
 		}
 
 		//map the options to the options property where array('id': [key], 'text': [nameField])
 		$nameField = $this->validator->arrayGet($options, 'name_field', $this->defaults['name_field']);
-		$keyField = $relatedModel->getKeyName();
+
+		//fixed bug in model config when filtering by foreign key (belongsTo)
+		$keyField = $relationship->getOtherKey();
 		$options['options'] = $this->mapRelationshipOptions($items, $nameField, $keyField);
 	}
 


### PR DESCRIPTION
There is some bugs when I use the type "relationship" in edit_fields and filters in model config file, it will update the id fields instead of the foreign key I've set in `belongsTo('\App\Models\MtrGroup', 'foreign_key', 'local_key')`. Details for issue can be seen on https://github.com/FrozenNode/Laravel-Administrator/issues/1048
This commit fixed bugs above for me, and I hope it can be merged and prevent similiar problems. 