### PR TITLE
Update package to Laravel 5.4

### DIFF
--- a/src/Frozennode/Administrator/AdministratorServiceProvider.php
+++ b/src/Frozennode/Administrator/AdministratorServiceProvider.php
@@ -59,7 +59,7 @@ class AdministratorServiceProvider extends ServiceProvider {
 		include __DIR__.'/../../routes.php';
 
 		//the admin validator
-		$this->app['admin_validator'] = $this->app->share(function($app)
+		$this->app->singleton('admin_validator',function($app)
 		{
 			//get the original validator class so we can set it back after creating our own
 			$originalValidator = LValidator::make(array(), array());
@@ -87,17 +87,17 @@ class AdministratorServiceProvider extends ServiceProvider {
 		});
 
 		//set up the shared instances
-		$this->app['admin_config_factory'] = $this->app->share(function($app)
+		$this->app->singleton('admin_config_factory',function($app)
 		{
 			return new ConfigFactory($app->make('admin_validator'), LValidator::make(array(), array()), config('administrator'));
 		});
 
-		$this->app['admin_field_factory'] = $this->app->share(function($app)
+		$this->app->singleton('admin_field_factory',function($app)
 		{
 			return new FieldFactory($app->make('admin_validator'), $app->make('itemconfig'), $app->make('db'));
 		});
 
-		$this->app['admin_datatable'] = $this->app->share(function($app)
+		$this->app->singleton('admin_datatable',function($app)
 		{
 			$dataTable = new DataTable($app->make('itemconfig'), $app->make('admin_column_factory'), $app->make('admin_field_factory'));
 			$dataTable->setRowsPerPage($app->make('session.store'), config('administrator.global_rows_per_page'));
@@ -105,17 +105,17 @@ class AdministratorServiceProvider extends ServiceProvider {
 			return $dataTable;
 		});
 
-		$this->app['admin_column_factory'] = $this->app->share(function($app)
+		$this->app->singleton('admin_column_factory',function($app)
 		{
 			return new ColumnFactory($app->make('admin_validator'), $app->make('itemconfig'), $app->make('db'));
 		});
 
-		$this->app['admin_action_factory'] = $this->app->share(function($app)
+		$this->app->singleton('admin_action_factory',function($app)
 		{
 			return new ActionFactory($app->make('admin_validator'), $app->make('itemconfig'), $app->make('db'));
 		});
 
-		$this->app['admin_menu'] = $this->app->share(function($app)
+		$this->app->singleton('admin_menu',function($app)
 		{
 			return new Menu($app->make('config'), $app->make('admin_config_factory'));
 		});


### PR DESCRIPTION
From the Laravel official documentation : 
https://laravel.com/docs/5.4/upgrade
share Method Removed

The share method has been removed from the container. This was a legacy method that has not been documented in several years. If you are using this method, you should begin using the singleton method instead:

```
$container->singleton('foo', function () {
    return 'foo';
});
```

This commit refactors the AdministratorServiceProvider.php to use singletons instead of the now deprecated share.